### PR TITLE
fix undefined dirname in _download

### DIFF
--- a/gmusicapi_wrapper/musicmanager.py
+++ b/gmusicapi_wrapper/musicmanager.py
@@ -169,8 +169,9 @@ class MusicManagerWrapper(_BaseWrapper):
 
 				metadata = mutagen.File(temp.name, easy=True)
 				filepath = template_to_filepath(template, metadata) + '.mp3'
+				dirname = os.path.dirname(filepath)
 
-				if os.path.dirname(filepath):
+				if dirname:
 					try:
 						os.makedirs(dirname)
 					except OSError:


### PR DESCRIPTION
dirname is an undefined variable in the _download function in MusicManagerWrapper.  I have been trying to use the `gmsync` program from `gmusicapi-scripts`, and this patch allows the program to run to completion.

```
NameError: name 'dirname' is not defined
```
