### PR TITLE
Account for mutagen.File returning None for unreadable files

### DIFF
--- a/gmusicapi_wrapper/utils.py
+++ b/gmusicapi_wrapper/utils.py
@@ -40,6 +40,9 @@ def _get_mutagen_metadata(filepath):
 		logger.warning("Can't load {} as music file.".format(filepath))
 		raise
 
+	if metadata is None:
+		logger.warning("Can't load {} as music file.".format(filepath))
+
 	return metadata
 
 
@@ -288,15 +291,18 @@ def filter_local_songs(filepaths, include_filters=None, exclude_filters=None, al
 		except mutagen.MutagenError:
 			filtered_songs.append(filepath)
 		else:
-			if include_filters or exclude_filters:
-				if _check_filters(
-						song, include_filters=include_filters, exclude_filters=exclude_filters,
-						all_includes=all_includes, all_excludes=all_excludes):
-					matched_songs.append(filepath)
-				else:
-					filtered_songs.append(filepath)
+			if song is None:
+				filtered_songs.append(filepath)
 			else:
-				matched_songs.append(filepath)
+				if include_filters or exclude_filters:
+					if _check_filters(
+							song, include_filters=include_filters, exclude_filters=exclude_filters,
+							all_includes=all_includes, all_excludes=all_excludes):
+						matched_songs.append(filepath)
+					else:
+						filtered_songs.append(filepath)
+				else:
+					matched_songs.append(filepath)
 
 	return matched_songs, filtered_songs
 


### PR DESCRIPTION
It seems to be possible for a file to be detected as a music file by gmusicapi-wrapper but for mutagen to detect it as a non music file. This results in mutagen.File returning None which eventually is treated as a dictionary, causing an unhandled exception.

This change checks the return value of mutagen.File and handles None similarly to how exceptions are currently handled (filename is logged and added to the filtered files list).