### PR TITLE
Avoid exception when re.match() doesn't find a match

### DIFF
--- a/gmusicapi_wrapper/utils.py
+++ b/gmusicapi_wrapper/utils.py
@@ -54,7 +54,7 @@ def _split_field_to_single_value(field):
 
 	split_field = re.match(r'(\d+)/\d+', field)
 
-	return split_field.group(1) or field
+	return split_field.group(1) if split_field is not None else field
 
 
 def _filter_comparison_fields(song):


### PR DESCRIPTION
In that case, `split_field` is None, and `split_field.group()` raises an exception.