### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'group'"...

### DIFF
--- a/gmusicapi_wrapper/utils.py
+++ b/gmusicapi_wrapper/utils.py
@@ -54,7 +54,7 @@ def _split_field_to_single_value(field):
 
 	split_field = re.match(r'(\d+)/\d+', field)
 
-	return split_field.group(1) or field
+	return split_field and split_field.group(1) or field
 
 
 def _filter_comparison_fields(song):


### PR DESCRIPTION
...on split_field.group(1).

Fixes error:

```
$ gmdownload '/music/%albumartist%/%album%/%track2% - %title%'                                                                              
MusicManagerWrapper authentication succeeded.

Loading Google Music songs...
Filtered 0 Google Music songs
Loaded 2343 Google Music songs

Downloading 2343 song(s) from Google Music

Traceback (most recent call last):
  File "/usr/local/bin/gmdownload", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_scripts/gmdownload.py", line 107, in main
    mmw.download(songs_to_download, template=cli['output'])
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/decorators.py", line 22, in wrapper
    return function(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/musicmanager.py", line 215, in download
    for result in self._download(songs, template):
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/musicmanager.py", line 171, in _download
    filepath = template_to_filepath(template, metadata) + '.mp3'
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/utils.py", line 393, in template_to_filepath
    filepath = _replace_template_patterns(t, metadata, template_patterns)
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/utils.py", line 346, in _replace_template_patterns
    track_number = _split_field_to_single_value(metadata[template_patterns[key]])
  File "/usr/local/lib/python3.4/dist-packages/gmusicapi_wrapper/utils.py", line 57, in _split_field_to_single_value
    return split_field.group(1) or field
AttributeError: 'NoneType' object has no attribute 'group'
```